### PR TITLE
Fixed log popup not appearing on new examine

### DIFF
--- a/src/main/java/com/dexamine/DexaminePlugin.java
+++ b/src/main/java/com/dexamine/DexaminePlugin.java
@@ -373,7 +373,9 @@ public class DexaminePlugin extends Plugin
 		if (!config.enableCollectionLogPopup()) {
 			return;
 		}
-		WidgetNode widgetNode = client.openInterface((161 << 16) | 13, 660, WidgetModalMode.MODAL_CLICKTHROUGH);
+
+		int tli = client.getTopLevelInterfaceId();
+		WidgetNode widgetNode = client.openInterface((tli << 16) | 13, 660, WidgetModalMode.MODAL_CLICKTHROUGH);
 		client.runScript(3343,
 				"Examine Log", String.format("New %s examine:<br><br><col=ffffff>%s</col>",
 				chatTypeToType(pendingExamine.getType()), pendingExamine.getExamineText()),


### PR DESCRIPTION
This closes #3 

It revises the componentId used to open the interface within the RuneLite client. It seems the hardcoded value that was used before in the RuneLite examples is outdated, as it utilizes 161 and the new top level interface id is 164 (at least on my version). To make it more versatile, I have simply called the client's getTopLevelInterfaceId function and used that instead of a hardcoded value.